### PR TITLE
Add theme as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "site/themes/hugo-theme-learn"]
+	path = site/themes/hugo-theme-learn
+	url = https://github.com/matcornic/hugo-theme-learn.git

--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ This workshop teaches you best practices for using ECS Fargate.  It has three in
 * Operations
 * Data engineering
 
-The full documentation is available in the `site` folder, and is best viewed with [Hugo](https://learn.netlify.app/en/basics/).  You can run Hugo locally by downloading Hugo for your platform, going to the `site` folder, and running `hugo serve`.
+The full documentation is available in the `site` folder, and is best viewed with [Hugo](https://learn.netlify.app/en/basics/).  You can run Hugo locally by following these steps:
+
+1. Download all dependencies by running `git submodule init` and `git submodule update`. If you run this a second time, you only have to do the latter.
+2. Downloading Hugo for your platform.
+3. Go to the `site` folder, and run `hugo serve`.
 
 ## License Summary
 


### PR DESCRIPTION
When you run `hugo serve` in the `sites` foler, you get the following error:

```
Error: module "hugo-theme-learn" not found; either add it as a Hugo Module or store it in "[absolute path]/amazon-ecs-fargate-workshop-dev-ops-data/site/themes".: module does not exist
```

This PR solves that by adding the theme as a submodule (I only did a quick google search to find the theme, please let me know if this isn't the right one)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
